### PR TITLE
Display device name in tray

### DIFF
--- a/modules/audio_devices.py
+++ b/modules/audio_devices.py
@@ -1,0 +1,27 @@
+import pyaudio
+
+
+def list_input_devices():
+    """Return a list of tuples (index, name) for available input devices."""
+    pa = pyaudio.PyAudio()
+    devices = []
+    try:
+        for i in range(pa.get_device_count()):
+            info = pa.get_device_info_by_index(i)
+            if info.get("maxInputChannels", 0) > 0:
+                devices.append((i, info.get("name")))
+    finally:
+        pa.terminate()
+    return devices
+
+
+def get_device_name(index: int) -> str | None:
+    """Return the device name for the given index or None if not found."""
+    pa = pyaudio.PyAudio()
+    try:
+        info = pa.get_device_info_by_index(index)
+        return info.get("name")
+    except Exception:
+        return None
+    finally:
+        pa.terminate()


### PR DESCRIPTION
## Summary
- list input audio devices and fetch device names
- show OSC address and device name in the tray menu
- expose selected device name to tray setup

## Testing
- `python3 -m py_compile ltc_reader.py modules/audio_devices.py`

------
https://chatgpt.com/codex/tasks/task_e_686e5737b7dc8327a2e10f57182ffa6f