### PR TITLE
Allow fps config and show it in tray

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,5 +4,6 @@
   "osc_address": "/ltc",
   "audio_device_index": 1,
   "channel": 0,
-  "sample_rate": 48000
+  "sample_rate": 48000,
+  "fps": 30
 }

--- a/ltc_reader.py
+++ b/ltc_reader.py
@@ -65,6 +65,16 @@ def _setup_tray(settings, exit_cb, device_name=None):
             None,
             enabled=False,
         ),
+        pystray.MenuItem(
+            f"Rate {settings['sample_rate']}Hz",
+            None,
+            enabled=False,
+        ),
+        pystray.MenuItem(
+            f"FPS {settings.get('fps', 30)}",
+            None,
+            enabled=False,
+        ),
     )
 
     icon.menu = pystray.Menu(
@@ -138,8 +148,8 @@ class LTCReader:
             input_device_index=self.device_index,
             frames_per_buffer=self.chunk_size,
         )
-        fps = 30.0
-        self.decoder = LibLTC(find_libltc(), self.sample_rate, fps)
+        self.fps = float(config.get("fps", 30))
+        self.decoder = LibLTC(find_libltc(), self.sample_rate, self.fps)
         self.osc = OSCClient(
             config.get("osc_ip", "127.0.0.1"),
             int(config.get("osc_port", 9000)),

--- a/readme.md
+++ b/readme.md
@@ -26,3 +26,20 @@ LTC（Linear Timecode）信号を**オーディオ入力からリアルタイム
 
 ```bash
 pip install pyaudio python-osc
+```
+
+## Configuration
+
+`config.json` で次の項目を設定できます。
+
+```json
+{
+  "osc_ip": "127.0.0.1",
+  "osc_port": 9000,
+  "osc_address": "/ltc",
+  "audio_device_index": 1,
+  "channel": 0,
+  "sample_rate": 48000,
+  "fps": 30
+}
+```


### PR DESCRIPTION
## Summary
- allow customizing fps via `config.json`
- display sample rate and fps in tray settings menu
- document configurable values in README

## Testing
- `python -m py_compile ltc_reader.py modules/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686e59306204832794c866a7fa651b77