### PR TITLE
Enable tray configuration editing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,8 @@ pip install -r requirements.txt
 
 ## Configuration
 
-`config.json` で次の項目を設定できます。
+`config.json` で次の項目を設定できます。実行中はトレイメニューから
+GUI設定ウィンドウを開き、値を変更して保存することもできます。
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ pip install -r requirements.txt
 ## Configuration
 
 `config.json` で次の項目を設定できます。実行中はトレイメニューから
-GUI設定ウィンドウを開き、値を変更して保存することもできます。
+GUI設定ウィンドウを開き、値を変更して保存すると自動的に再起動します。
 
 ```json
 {


### PR DESCRIPTION
## Summary
- add a Tkinter based config editor window
- expose the config editor from the system tray
- document how config can be edited while running

## Testing
- `python3 -m py_compile ltc_reader.py modules/*.py modules/communication/*.py`
- `python3 ltc_reader.py --config config.json` *(fails: ModuleNotFoundError: No module named 'pyaudio')*

------
https://chatgpt.com/codex/tasks/task_e_686e619be08c83278a6890f77c4f85e2